### PR TITLE
Adding support of passing project-specific configuration to code sniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,14 @@
         "squizlabs/php_codesniffer": "dev-api-friendly as 3.x-dev",
         "drupal/coder": "^8.3",
         "phpmd/phpmd": "dev-api-friendly",
-        "phploc/phploc": "^6.0"
+        "phploc/phploc": "^6.0",
+        "symfony/console": "^5.2"
     },
     "require-dev": {
         "clue/phar-composer": "^1.1"
     },
+	"autoload": {
+	  "psr-0": { "": "src/" }
+	},
     "bin": ["src/index.php"]
 }

--- a/src/PHPDebt/Console/Command/CodeSnifferConfigCommand.php
+++ b/src/PHPDebt/Console/Command/CodeSnifferConfigCommand.php
@@ -35,7 +35,7 @@ class CodeSnifferConfigCommand extends Command {
 	/**
 	 * {@inheritdoc}
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output): int {
+	protected function execute(InputInterface $input, OutputInterface $output) {
 		$code_faults = 0;
 		$standards_faults = 0;
 		$path = $input->getArgument('path');
@@ -51,13 +51,15 @@ class CodeSnifferConfigCommand extends Command {
 		$runner = new Runner();
 		// If PHPCS config is provided, then execute this.
 		if ($option) {
+			define('PHP_CODESNIFFER_CBF', FALSE);
 			$runner->config = new Config(["--standard=$option"]);
-			$runner->init();
 
+			$runner->init();
 			$faults = $runner->run();
 			print "phpcs Drupal: " . $faults . "\n";
 			$standards_faults += $faults;
 
+			$runner->init();
 			$faults = $runner->run();
 			print "phpcs DrupalPractice: " . $faults . "\n";
 			$standards_faults += $faults;
@@ -90,7 +92,7 @@ class CodeSnifferConfigCommand extends Command {
 			$standards_faults += $faults;
 		}
 
-		// Lines of Code
+		// Lines of Code should be working on and anything unique about getting his local back up to date?
 		$files = (new FinderFacade([$path], [], ['*.php', '*.module', '*.install', '*.inc', '*.js', '*.scss'], []))->findFiles();
 		$count = (new Analyser)->countFiles($files, TRUE);
 		$total_lines = $count['ncloc'];

--- a/src/PHPDebt/Console/Command/CodeSnifferConfigCommand.php
+++ b/src/PHPDebt/Console/Command/CodeSnifferConfigCommand.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace PHPDebt\Console\Command;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Runner;
+use PHPDebt\PHPDebtMD;
+use SebastianBergmann\FinderFacade\FinderFacade;
+use SebastianBergmann\PHPLOC\Analyser;
+use Symfony\Component\Console\{
+	Command\Command,
+	Input\InputArgument,
+	Input\InputInterface,
+	Input\InputOption,
+	Output\OutputInterface
+};
+
+/**
+ * The class for all `phpdebt` command.
+ *
+ * @package PHPDebt\Console\Command
+ */
+class CodeSnifferConfigCommand extends Command {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure() {
+		$this->setName('phpdebt')
+			->addArgument('path', InputArgument::REQUIRED, 'The path of the file or directory that needs to be scanned.')
+			->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The path of the phpcs.xml.dist')
+			->setDescription('Enables option of utilizing project based PHPCS Config.');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$code_faults = 0;
+		$standards_faults = 0;
+		$path = $input->getArgument('path');
+		$option = $input->getOption('standard');
+
+		$debt_md = new PHPDebtMD();
+		$code_faults += $debt_md->process($path, 'cleancode');
+		$code_faults += $debt_md->process($path, 'codesize');
+		$code_faults += $debt_md->process($path, 'design');
+		$code_faults += $debt_md->process($path, 'naming');
+		$code_faults += $debt_md->process($path, 'unusedcode');
+
+		$runner = new Runner();
+		// If PHPCS config is provided, then execute this.
+		if ($option) {
+			$runner->config = new Config(["--standard=$option"]);
+			$runner->init();
+
+			$faults = $runner->run();
+			print "phpcs Drupal: " . $faults . "\n";
+			$standards_faults += $faults;
+
+			$faults = $runner->run();
+			print "phpcs DrupalPractice: " . $faults . "\n";
+			$standards_faults += $faults;
+		}
+		else {
+			$runner->config = new Config();
+			$runner->config->files = [$path];
+			$runner->config->standards = ['Drupal'];
+			$runner->config->extensions = [
+				'php'     => 'PHP',
+				'module'  => 'PHP',
+				'inc'     => 'PHP',
+				'install' => 'PHP',
+				'test'    => 'PHP',
+				'profile' => 'PHP',
+				'theme'   => 'PHP',
+				'css'     => 'CSS',
+				'info'    => 'PHP',
+				'js'      => 'JS',
+			];
+			$runner->init();
+			$faults = $runner->run();
+			print "phpcs Drupal: " . $faults . "\n";
+			$standards_faults += $faults;
+
+			$runner->config->standards = ['DrupalPractice'];
+			$runner->init();
+			$faults = $runner->run();
+			print "phpcs DrupalPractice: " . $faults . "\n";
+			$standards_faults += $faults;
+		}
+
+		// Lines of Code
+		$files = (new FinderFacade([$path], [], ['*.php', '*.module', '*.install', '*.inc', '*.js', '*.scss'], []))->findFiles();
+		$count = (new Analyser)->countFiles($files, TRUE);
+		$total_lines = $count['ncloc'];
+
+		$faults = $code_faults + $standards_faults;
+		$percent = ($faults / $total_lines) * 100;
+
+		// Summary
+		print "Total Faults: " . $faults . "\n";
+		print "Total Lines: " . $total_lines . "\n";
+		print "Quality Score: " . number_format($percent, 2) . " faults per 100 lines\n";
+
+		$ratio = 200;
+		$base = ($total_lines / $ratio) * sqrt($percent);
+
+		if ($percent > 25) {
+			$hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 25));
+			print "Estimate to get to 25: " . number_format($base - $hours, 2) . " hours\n";
+		}
+
+		if ($percent > 10) {
+			$hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 10));
+			print "Estimate to get to 10: " . number_format($base - $hours, 2) . " hours\n";
+		}
+
+		if ($percent > 5) {
+			$hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 5));
+			print "Estimate to get to 5: " . number_format($base - $hours, 2) . " hours\n";
+		}
+
+		if ($percent > 3) {
+			$hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 3));
+			print "Estimate to get to 3: " . number_format($base - $hours, 2) . " hours\n";
+		}
+		return 0;
+	}
+
+}

--- a/src/PHPDebt/Console/Command/PHPDebtCommand.php
+++ b/src/PHPDebt/Console/Command/PHPDebtCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\{
  *
  * @package PHPDebt\Console\Command
  */
-class CodeSnifferConfigCommand extends Command {
+class PHPDebtCommand extends Command {
 
 	/**
 	 * {@inheritdoc}
@@ -29,7 +29,7 @@ class CodeSnifferConfigCommand extends Command {
 		$this->setName('phpdebt')
 			->addArgument('path', InputArgument::REQUIRED, 'The path of the file or directory that needs to be scanned.')
 			->addOption('standard', 's', InputOption::VALUE_REQUIRED, 'The path of the phpcs.xml.dist')
-			->setDescription('Enables option of utilizing project based PHPCS Config.');
+			->setDescription('This tool provides code quality score based on a number of standards from existing code analysis tools.');
 	}
 
 	/**
@@ -53,13 +53,13 @@ class CodeSnifferConfigCommand extends Command {
 		if ($option) {
 			define('PHP_CODESNIFFER_CBF', FALSE);
 			$runner->config = new Config(["--standard=$option"]);
+			$runner->config->files = [$path];
 
 			$runner->init();
 			$faults = $runner->run();
 			print "phpcs Drupal: " . $faults . "\n";
 			$standards_faults += $faults;
 
-			$runner->init();
 			$faults = $runner->run();
 			print "phpcs DrupalPractice: " . $faults . "\n";
 			$standards_faults += $faults;

--- a/src/PHPDebt/PHPDebtMD.php
+++ b/src/PHPDebt/PHPDebtMD.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PHPDebt;
+
+use PHPMD\PHPMD;
+use PHPMD\RuleSetFactory;
+
+/**
+ * The main facade of the PHPDebt's PHPMD application.
+ *
+ * @package PHPDebt
+ */
+class PHPDebtMD {
+
+	/**
+	 * This methods does the job of returning the rule violations as per PHPMD.
+	 *
+	 * @param string $path
+	 *   The provided path that needs to be scanned.
+	 * @param string $type
+	 *   The received ruleset.
+	 *
+	 * @return int|void
+	 */
+	public function process(string $path, string $type) {
+		$ruleSetFactory = new RuleSetFactory();
+		$phpmd = new PHPMD();
+
+		$report = $phpmd->runReport(
+			$path,
+			$type,
+			$ruleSetFactory
+		);
+
+		$faults = count($report->getRuleViolations());
+
+		print "phpmd " . $type . ": " . $faults . "\n";
+
+		return count($report->getRuleViolations());
+	}
+
+}

--- a/src/index.php
+++ b/src/index.php
@@ -3,10 +3,10 @@
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';
 
-use PHPDebt\Console\Command\CodeSnifferConfigCommand;
+use PHPDebt\Console\Command\PHPDebtCommand;
 use Symfony\Component\Console\Application;
 
-$command = new CodeSnifferConfigCommand();
+$command = new PHPDebtCommand();
 $app = new Application();
 $app->add($command);
 $app->setDefaultCommand($command->getName(), TRUE);

--- a/src/index.php
+++ b/src/index.php
@@ -57,6 +57,12 @@ $runner->config->extensions = [
     'info' => 'PHP',
     'js' => 'JS'
 ];
+// Accepting an argument here, this can be used to accept the PHPCS config file
+// that will override the above options.
+// Example: phpdebt module/path --standard=web/core/phpcs.xml.dist
+if (isset($argv[1])) {
+	$runner->config = new Config([$argv[1]]);
+}
 $runner->init();
 
 $faults = $runner->run();

--- a/src/index.php
+++ b/src/index.php
@@ -12,6 +12,7 @@ use SebastianBergmann\PHPLOC\Analyser;
 use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Config;
 
+$options = getopt(NULL, ['standard:']);
 $code_faults = 0;
 $standards_faults = 0;
 $path = $argv[1];
@@ -59,9 +60,9 @@ $runner->config->extensions = [
 ];
 // Accepting an argument here, this can be used to accept the PHPCS config file
 // that will override the above options.
-// Example: phpdebt module/path --standard=web/core/phpcs.xml.dist
-if (isset($argv[1])) {
-	$runner->config = new Config([$argv[1]]);
+// Example: phpdebt module/path --standard=./phpcs.xml.dist
+if (isset($options['standard'])) {
+	$runner->config = new Config($options);
 }
 $runner->init();
 

--- a/src/index.php
+++ b/src/index.php
@@ -3,111 +3,11 @@
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';
 
-use PHPMD\PHPMD;
-use PHPMD\RuleSetFactory;
+use PHPDebt\Console\Command\CodeSnifferConfigCommand;
+use Symfony\Component\Console\Application;
 
-use SebastianBergmann\FinderFacade\FinderFacade;
-use SebastianBergmann\PHPLOC\Analyser;
-
-use PHP_CodeSniffer\Runner;
-use PHP_CodeSniffer\Config;
-
-$options = getopt(NULL, ['standard:']);
-$code_faults = 0;
-$standards_faults = 0;
-$path = $argv[1];
-
-function phpMD($path, $type) {
-    $ruleSetFactory = new RuleSetFactory();
-    $phpmd = new PHPMD();
-
-    $report = $phpmd->runReport(
-        $path,
-        $type,
-        $ruleSetFactory
-    );
-
-    $faults = count($report->getRuleViolations());
-
-    print "phpmd " . $type . ": " . $faults . "\n";
-
-    return count($report->getRuleViolations());
-}
-
-$code_faults += phpMD($path, 'cleancode');
-$code_faults += phpMD($path, 'codesize');
-$code_faults += phpMD($path, 'design');
-$code_faults += phpMD($path, 'naming');
-$code_faults += phpMD($path, 'unusedcode');
-
-
-$runner = new Runner();
-
-$runner->config = new Config();
-$runner->config->files = [$path];
-$runner->config->standards = ['Drupal'];
-$runner->config->extensions = [
-    'php' => 'PHP',
-    'module' => 'PHP',
-    'inc' => 'PHP',
-    'install' => 'PHP',
-    'test' => 'PHP',
-    'profile' => 'PHP',
-    'theme' => 'PHP',
-    'css' => 'CSS',
-    'info' => 'PHP',
-    'js' => 'JS'
-];
-// Accepting an argument here, this can be used to accept the PHPCS config file
-// that will override the above options.
-// Example: phpdebt module/path --standard=./phpcs.xml.dist
-if (isset($options['standard'])) {
-	$runner->config = new Config($options);
-}
-$runner->init();
-
-$faults = $runner->run();
-print "phpcs Drupal: " . $faults . "\n";
-$standards_faults += $faults;
-
-$runner->config->standards = ['DrupalPractice'];
-$runner->init();
-$faults = $runner->run();
-print "phpcs DrupalPractice: " . $faults . "\n";
-$standards_faults += $faults;
-
-// Lines of Code
-$files = (new FinderFacade([$path], [], ['*.php', '*.module', '*.install', '*.inc', '*.js', '*.scss'], []))->findFiles();
-$count = (new Analyser)->countFiles($files, true);
-$total_lines = $count['ncloc'];
-
-$faults = $code_faults + $standards_faults;
-$percent = ($faults / $total_lines) * 100;
-
-// Summary
-print "Total Faults: " . $faults . "\n";
-print "Total Lines: " . $total_lines . "\n";
-print "Quality Score: " . number_format($percent, 2) . " faults per 100 lines\n";
-
-$ratio = 200;
-$base = ($total_lines / $ratio) * sqrt($percent);
-
-if ($percent > 25) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 25));
-    print "Estimate to get to 25: " . number_format($base - $hours, 2) . " hours\n";
-}
-
-if ($percent > 10) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 10));
-    print "Estimate to get to 10: " . number_format($base - $hours, 2) . " hours\n";
-}
-
-if ($percent > 5) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 5));
-    print "Estimate to get to 5: " . number_format($base - $hours, 2) . " hours\n";
-}
-
-if ($percent > 3) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 3));
-    print "Estimate to get to 3: " . number_format($base - $hours, 2) . " hours\n";
-}
+$command = new CodeSnifferConfigCommand();
+$app = new Application();
+$app->add($command);
+$app->setDefaultCommand($command->getName(), true);
+$app->run();

--- a/src/index.php
+++ b/src/index.php
@@ -9,5 +9,5 @@ use Symfony\Component\Console\Application;
 $command = new CodeSnifferConfigCommand();
 $app = new Application();
 $app->add($command);
-$app->setDefaultCommand($command->getName(), true);
+$app->setDefaultCommand($command->getName(), TRUE);
 $app->run();


### PR DESCRIPTION
Now `phpdebt` can be allowed to use the PHPCS config via:

`phpdebt <path-of-dir/file-to-be-scanned> --standard=phpcs.xml.dist`