### PR TITLE
Upgrade corresponding library to make sure it is compatible with php 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cp vendor/drupal/coder/coder_sniffer/Drupal/ vendor/squizlabs/php_codesniffer/src/Standards/ -r
-cp vendor/drupal/coder/coder_sniffer/DrupalPractice/ vendor/squizlabs/php_codesniffer/src/Standards/ -r
+cp -R vendor/drupal/coder/coder_sniffer/Drupal vendor/squizlabs/php_codesniffer/src/Standards
+cp -R vendor/drupal/coder/coder_sniffer/DrupalPractice vendor/squizlabs/php_codesniffer/src/Standards
 rm phpdebt.phar
-./vendor/bin/phar-composer build . 
+./vendor/bin/phar-composer build .

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,15 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/smmccabe/phpmd.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/smmccabe/PHP_CodeSniffer.git"
+            "url": "https://github.com/cobenash/PHP_CodeSniffer.git"
         }
     ],
     "require": {
         "squizlabs/php_codesniffer": "dev-api-friendly as 3.x-dev",
-        "drupal/coder": "^8.3",
-        "phpmd/phpmd": "dev-api-friendly",
-        "phploc/phploc": "^6.0"
+        "drupal/coder": "8.3.13",
+        "phpmd/phpmd": "^2.13",
+        "phploc/phploc": "^7.0",
+        "symfony/finder": "^6.2"
     },
     "require-dev": {
         "clue/phar-composer": "^1.1"

--- a/src/index.php
+++ b/src/index.php
@@ -1,43 +1,55 @@
 <?php
 
+/**
+ * @file
+ * PHP Technical Debt Calculator.
+ */
+
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';
 
 use PHPMD\PHPMD;
+use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 
-use SebastianBergmann\FinderFacade\FinderFacade;
 use SebastianBergmann\PHPLOC\Analyser;
 
 use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Config;
 
+use Symfony\Component\Finder\Finder;
+
 $code_faults = 0;
 $standards_faults = 0;
 $path = $argv[1];
 
-function phpMD($path, $type) {
-    $ruleSetFactory = new RuleSetFactory();
-    $phpmd = new PHPMD();
-
-    $report = $phpmd->runReport(
+/**
+ * Mess Detector function.
+ */
+function php_md($path, $type) {
+  $ruleSetFactory = new RuleSetFactory();
+  $phpmd = new PHPMD();
+  $report = new Report();
+  $phpmd->processFiles(
         $path,
         $type,
-        $ruleSetFactory
+        $render = [],
+        $ruleSetFactory,
+        $report,
     );
 
-    $faults = count($report->getRuleViolations());
+  $faults = count($report->getRuleViolations());
 
-    print "phpmd " . $type . ": " . $faults . "\n";
+  print "phpmd " . $type . ": " . $faults . "\n";
 
-    return count($report->getRuleViolations());
+  return count($report->getRuleViolations());
 }
 
-$code_faults += phpMD($path, 'cleancode');
-$code_faults += phpMD($path, 'codesize');
-$code_faults += phpMD($path, 'design');
-$code_faults += phpMD($path, 'naming');
-$code_faults += phpMD($path, 'unusedcode');
+$code_faults += php_md($path, 'cleancode');
+$code_faults += php_md($path, 'codesize');
+$code_faults += php_md($path, 'design');
+$code_faults += php_md($path, 'naming');
+$code_faults += php_md($path, 'unusedcode');
 
 
 $runner = new Runner();
@@ -46,16 +58,16 @@ $runner->config = new Config();
 $runner->config->files = [$path];
 $runner->config->standards = ['Drupal'];
 $runner->config->extensions = [
-    'php' => 'PHP',
-    'module' => 'PHP',
-    'inc' => 'PHP',
-    'install' => 'PHP',
-    'test' => 'PHP',
-    'profile' => 'PHP',
-    'theme' => 'PHP',
-    'css' => 'CSS',
-    'info' => 'PHP',
-    'js' => 'JS'
+  'php' => 'PHP',
+  'module' => 'PHP',
+  'inc' => 'PHP',
+  'install' => 'PHP',
+  'test' => 'PHP',
+  'profile' => 'PHP',
+  'theme' => 'PHP',
+  'css' => 'CSS',
+  'info' => 'PHP',
+  'js' => 'JS',
 ];
 $runner->init();
 
@@ -69,15 +81,22 @@ $faults = $runner->run();
 print "phpcs DrupalPractice: " . $faults . "\n";
 $standards_faults += $faults;
 
-// Lines of Code
-$files = (new FinderFacade([$path], [], ['*.php', '*.module', '*.install', '*.inc', '*.js', '*.scss'], []))->findFiles();
-$count = (new Analyser)->countFiles($files, true);
+// Lines of code.
+$finder = Finder::create();
+$finder->files()->in($path)->filter(static function (SplFileInfo $file) {
+    return $file->isDir() || \preg_match('/\.(php|module|install|inc|js|scss)$/', $file->getPathname());
+});
+$files = [];
+foreach ($finder as $file) {
+  $files[] = $file->getRealPath();
+}
+$count = (new Analyser)->countFiles($files, TRUE);
 $total_lines = $count['ncloc'];
 
 $faults = $code_faults + $standards_faults;
 $percent = ($faults / $total_lines) * 100;
 
-// Summary
+// Summary.
 print "Total Faults: " . $faults . "\n";
 print "Total Lines: " . $total_lines . "\n";
 print "Quality Score: " . number_format($percent, 2) . " faults per 100 lines\n";
@@ -86,21 +105,21 @@ $ratio = 200;
 $base = ($total_lines / $ratio) * sqrt($percent);
 
 if ($percent > 25) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 25));
-    print "Estimate to get to 25: " . number_format($base - $hours, 2) . " hours\n";
+  $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 25));
+  print "Estimate to get to 25: " . number_format($base - $hours, 2) . " hours\n";
 }
 
 if ($percent > 10) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 10));
-    print "Estimate to get to 10: " . number_format($base - $hours, 2) . " hours\n";
+  $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 10));
+  print "Estimate to get to 10: " . number_format($base - $hours, 2) . " hours\n";
 }
 
 if ($percent > 5) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 5));
-    print "Estimate to get to 5: " . number_format($base - $hours, 2) . " hours\n";
+  $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 5));
+  print "Estimate to get to 5: " . number_format($base - $hours, 2) . " hours\n";
 }
 
 if ($percent > 3) {
-    $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 3));
-    print "Estimate to get to 3: " . number_format($base - $hours, 2) . " hours\n";
+  $hours = ($total_lines / $ratio) * sqrt($percent - ($percent - 3));
+  print "Estimate to get to 3: " . number_format($base - $hours, 2) . " hours\n";
 }


### PR DESCRIPTION
## Update
1. Add symfony/finder to replace the unmaintained library finder-facade.
2. Change the outdated forked repository `smmccabe/PHP_CodeSniffer` to `cobenash/PHP_CodeSniffer` for testing purpose. It could be changed back if we update the original.

## Pre-release
https://github.com/cobenash/phpdebt/releases

Please take a look and see if it is workable.

